### PR TITLE
fix: lower memory usage in parallel grid correction

### DIFF
--- a/src/dart_bias_correct/forecast.py
+++ b/src/dart_bias_correct/forecast.py
@@ -437,7 +437,7 @@ def bias_correct_forecast_parallel(
     weekly_raw_forecast = get_weekly_forecast(data_raw_forecast)
     corrected_forecast = weekly_raw_forecast.copy(deep=True)
     corrected_forecast = corrected_forecast[BIAS_CORRECT_VARS]
-    corrected_coords = set()
+    corrected_coords: set[GridPoint] = set()
 
     def apply_patch(patch: list[GridPointValue]):
         for var, s, lat_idx, lon_idx, time, value in patch:


### PR DESCRIPTION
Previous iteration of correct_grid_point() initialised two full numpy
arrays across the entire grid, one to update the corrected forecast, and
another to keep track of already corrected points. This caused OOM on
non-trivial grids, such as 65x33 latlon grid for Vietnam with 50
simulations.

This iteration fixes this issue by returning a list of grid points to
correct from correct_grid_point() - this list is sparse and consumes
less memory. The list of corrected grid points is used to update a
tracker so that we can skip corrected grid points and to update the
corrected forecast.  Grid point search in later percentiles are also
faster as corrected grid points are immediately skipped.
