### PR TITLE
feat: faster forecast bias correction (serial)

### DIFF
--- a/src/dart_bias_correct/forecast.py
+++ b/src/dart_bias_correct/forecast.py
@@ -643,7 +643,7 @@ def bias_correct_forecast(
                     # and check that datapoints selected were not already corrected
 
                     filtered_valid_data = valid_data.where(
-                        bool_dataset[var].loc[sim_coords(valid_data, s)] < 1, drop=True
+                        bool_dataset[var].loc[sim_coords(valid_data, s)] == False, drop=True
                     )
                     if filtered_valid_data.size == 0:
                         continue
@@ -676,7 +676,7 @@ def bias_correct_forecast(
                             sim_coords(corr_data, s)
                         ]
                         non_nan_coords = corr_data.where(
-                            int_bool_dataset == 0, drop=True
+                            int_bool_dataset == False, drop=True
                         ).stack(
                             all_coords=("lat", "lon", "time")
                         )  # Filter already corrected data


### PR DESCRIPTION
Speed up forecast bias correction by 20x by not looping over lat, lon.
Patches are corrected in one go, with already corrected indices kept
track in a boolean DataArray. Already corrected indices are dropped
before assigning the new patch.

Co-authored-by: Iago Perez Fernandez <68069957+Winter-23@users.noreply.github.com>
